### PR TITLE
Remove unnecessary http variable

### DIFF
--- a/code/streetview-reality/index.html
+++ b/code/streetview-reality/index.html
@@ -10,5 +10,5 @@
     </style>
 </head>
   <body></body>
-  <script src="reality.js?v=2"></script>
+  <script src="reality.js"></script>
 </html>


### PR DESCRIPTION
This technique is typically used to prevent caching while testing applications.
This is not a required line of code and can safely be removed.